### PR TITLE
Jinja2 usage and some fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ Example
 * Then type language of title with `--lang` attribute (by default its 'en')
 * Don't forget to choose directory for saving scs files and images. Make it with `--dir` attribute (by default its 'sc_out')
 * Select external source with attribute `--source` from 'wiki' and 'google' (by default its 'wiki')
-* If you want to get information about entity with context (relations with other entities and etc.) use `--context=yes` (by default its 'no')
-* To get an intermediate JSON file use `--debug=yes` (by default its 'no')
+* If you want to get information about entity with context (relations with other entities and etc.) use `--context` (by default its 'False')
+* To get an intermediate JSON file use `--debug` (by default its 'False')
 
 Example with attributes
 
-    python3 parse.py Минск --lang=ru --dir=output_dir --debug=yes
+    python3 parse.py Минск --lang=ru --dir=output_dir --debug
 
 For help enter
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ You can see 3 sections:
 
 In `entities` section stores info about all entities which was loaded from external sources. Each entity include `identifier`, `label` and `description`. `label` and `description` include information in different languages. If loaded entity has image in `image_url` stores URL for loading this image.
 
-For `relations` section stores info about relations. All the same as in `entities` section but relations usually don't have images.
+In `relations` section stores info about relations. All the same as in `entities` section but relations usually don't have images.
 
-In `triplets` section stores relations between entities. It is represented in form of triplets, where the first element is the entity from which a relation goes to the second entity. Second element is the relation that two entities. Third element is second entity.
+In `triplets` section stores relations between entities. It is represented in form of triplets, where the first element is the entity from which a relation goes to the second entity. Second element is the relation that connect two entities. Third element is second entity.
 
 After loading data JSON file translating by JsonToScsTranslator and all info saves to SCs files.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 bs4
 requests
 wptools
+jinja2

--- a/src/loaders/WikiDataWithContextLoader.py
+++ b/src/loaders/WikiDataWithContextLoader.py
@@ -1,5 +1,6 @@
 from .WikiDataLoader import WikiDataLoader
 import wptools
+import re
 
 
 class WikiDataWithContextLoader(WikiDataLoader):
@@ -19,7 +20,11 @@ class WikiDataWithContextLoader(WikiDataLoader):
             rlt_ru_page = wptools.page(wikibase=rlt, lang='ru', skip=[
                                        'labels', 'imageinfo'], silent=True)
             rlt_ru_page.get_wikidata()
-            rlt_id = rlt_page.data['title']
+            if 'title' in rlt_page.data:
+                rlt_id = re.sub(
+                    r"\+|-|–|\/|:|\s", '_', re.sub(r"'s?|\(|\)|,", '', rlt_page.data['title']))
+            else:
+                continue
 
             self._info['relations'][rlt_id] = {
                 'identifier': rlt_id,
@@ -39,9 +44,10 @@ class WikiDataWithContextLoader(WikiDataLoader):
                         ent_ru_page = wptools.page(wikibase=ent, lang='ru', skip=[
                                                    'labels', 'imageinfo'], silent=True)
                         ent_ru_page.get_wikidata()
-                        try:
-                            ent_id = ent_page.data['title']
-                        except KeyError:
+                        if 'title' in ent_page.data:
+                            ent_id = re.sub(
+                                r"\+|-|–|\/|:|\s", '_', re.sub(r"'s?|\(|\)|,", '', ent_page.data['title']))
+                        else:
                             continue
 
                         self._info['entities'][ent_id] = {

--- a/src/parse.py
+++ b/src/parse.py
@@ -38,7 +38,7 @@ def parse(entities, save_dir='sc_out', lang='en', loader='wiki', with_context=Fa
 
 def args_parser_init():
     parser = argparse.ArgumentParser(
-        description='Loader from external sources')
+        description='Module for parsing external sources into SC-code')
     parser.add_argument('entities', metavar='ENT', type=str,
                         nargs='+', help="Searched entities")
     parser.add_argument(
@@ -47,18 +47,11 @@ def args_parser_init():
                         help='Enter directory to save scs files')
     parser.add_argument("--source", choices=["wiki", "google"],
                         default="wiki", type=str, help="Select external source")
-    parser.add_argument("--context", choices=["yes", "no"], default='no',
-                        type=str, help="Get entity with context (works only with Wiki)")
-    parser.add_argument(
-        "--debug", choices=['yes', 'no'], default='no', type=str, help='If True, also saves json file')
+    parser.add_argument("--context", action='store_true',
+                        help="Get entity with context (works only with Wiki)")
+    parser.add_argument("--debug", action='store_true',
+                        help='If True, also saves JSON file')
     return parser
-
-
-def word2bool(word):
-    if word == 'yes':
-        return True
-    else:
-        return False
 
 
 if __name__ == "__main__":
@@ -66,5 +59,5 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    parse(args.entities, args.dir, args.lang, args.source,
-          word2bool(args.context), word2bool(args.debug))
+    parse(args.entities, args.dir, args.lang,
+          args.source, args.context, args.debug)

--- a/src/templates/entity.scs
+++ b/src/templates/entity.scs
@@ -1,0 +1,18 @@
+{{identifier}}
+=> nrel_main_idtf:{% for lang, label in labels %}
+	[{{label}}] (* <- lang_{{lang}};; *);{% endfor %}
+<- rrel_key_sc_element: ...
+    (*
+	    <- sc_definition;;
+	    <= nrel_sc_text_translation:{% for lang, description in descriptions %}
+		    ... (* -> rrel_example: [{{description}}] (* <-lang_{{lang}};; *);; *);{% endfor %};
+    *);
+{% if img_name %}<- rrel_key_sc_element: ...
+    (*
+	    <-sc_illustration;;
+	    <=nrel_sc_text_translation: ...
+	    (*
+		    -> rrel_example: "file://images/{{img_name}}" (* => nrel_format: format_{{img_format}};; *);;
+	    *);;
+    *);{% endif %}	
+<-sc_node_not_relation;;

--- a/src/templates/relation.scs
+++ b/src/templates/relation.scs
@@ -1,0 +1,10 @@
+{{identifier}}
+=> nrel_main_idtf:{% for lang, label in labels %}
+	[{{label}}] (* <- lang_{{lang}};; *);{% endfor %}
+<- rrel_key_sc_element: ...
+    (*
+	    <- sc_definition;;
+	    <= nrel_sc_text_translation:{% for lang, description in descriptions %}
+		    ... (* -> rrel_example: [{{description}}] (* <-lang_{{lang}};; *);; *);{% endfor %};
+    *);	
+<-sc_node_norole_relation;;

--- a/src/templates/triplets.scs
+++ b/src/templates/triplets.scs
@@ -1,0 +1,2 @@
+{% for first_entity, relation, second_entity in triplets %}{{first_entity}} => {{relation}}: {{second_entity}};;
+{% endfor %}

--- a/src/translators/JsonToScsTranslator.py
+++ b/src/translators/JsonToScsTranslator.py
@@ -2,6 +2,7 @@ import json
 import requests
 import re
 import os
+from jinja2 import Environment, FileSystemLoader
 
 
 def json_to_scs(raw_info, save_dir):
@@ -14,75 +15,52 @@ def json_to_scs(raw_info, save_dir):
         os.mkdir('images')
     except FileExistsError:
         pass
+
     info = json.loads(raw_info)
+    jinja_env = Environment(loader=FileSystemLoader(os.path.realpath(
+        '{}/../templates'.format(os.path.dirname(os.path.realpath(__file__))))))
 
+    template = jinja_env.get_template('entity.scs')
     for ent in info['entities'].values():
-        try:
-            translate_entity(ent)
-        except Exception:
-            continue
+        translate_entity(ent, template)
 
+    template = jinja_env.get_template('relation.scs')
     for rlt in info['relations'].values():
-        try:
-            translate_relation(rlt)
-        except Exception:
-            continue
+        translate_relation(rlt, template)
 
-    for triplet in info['triplets']:
+    template = jinja_env.get_template('triplets.scs')
+    if len(info['triplets']) != 0:
         scs = open('triplets.scs', 'at', encoding='utf-8')
-        scs.write('{} => {}: {};;\n'.format(
-            triplet[0], triplet[1], triplet[2]))
+        scs.write(template.render(triplets=info['triplets']))
         scs.close()
 
 
-def translate_entity(ent):
-    scs = open('{}.scs'.format(ent['identifier']), 'wt', encoding='utf-8')
-    scs.write(ent['identifier']+'\n')
-    scs.write('=> nrel_main_idtf:\n')
-    for lang, label in ent['label'].items():
-        scs.write('\t[{}] (* <- lang_{};; *);\n'.format(label, lang))
-    scs.write(
-        '<- rrel_key_sc_element: ...\n(*\n\t<- sc_definition;;\n\t<= nrel_sc_text_translation:')
-    for lang, description in ent['description'].items():
-        scs.write(
-            '\n\t\t... (* -> rrel_example: [{}] (* <-lang_{};; *);; *);'.format(description, lang))
-    scs.write(';\n*);\n')
-
-    try:
-        image_url = ent['image_url']
-        image_format = re.findall(r'\.\w*$', image_url)[0]
-        image_format = image_format[1:]
+def translate_entity(entity, template):
+    if 'image_url' in entity:
+        image_url = entity['image_url']
+        image_format = re.findall(r'\.\w*$', image_url)[0][1:]
+        image_name = '{}_image.{}'.format(entity['identifier'], image_format)
         image = requests.get(image_url)
         os.chdir('images')
         image_file = open('{}_image.{}'.format(
-            ent['identifier'], image_format), 'wb')
+            entity['identifier'], image_format), 'wb')
         image_file.write(image.content)
         image_file.close()
         os.chdir('..')
-        scs.write(
-            '<- rrel_key_sc_element: ...\n(*\n\t<-sc_illustration;;\n\t<=nrel_sc_text_translation: ...\n')
-        scs.write('\t(*\n\t\t-> rrel_example: "file://images/{}_image.{}"'.format(
-            ent['identifier'], image_format))
-        scs.write(
-            ' (* => nrel_format: format_{};; *);;\n\t*);;\n*);\n'.format(image_format))
-    except KeyError:
-        pass
 
-    scs.write('<-sc_node_not_relation;;')
+        rendered_tmpl = template.render(identifier=entity['identifier'], labels=entity['label'].items(
+        ), descriptions=entity['description'].items(), img_name=image_name, img_format=image_format)
+    else:
+        rendered_tmpl = template.render(identifier=entity['identifier'], labels=entity['label'].items(
+        ), descriptions=entity['description'].items())
+
+    scs = open('{}.scs'.format(entity['identifier']), 'wt', encoding='utf-8')
+    scs.write(rendered_tmpl)
     scs.close()
 
 
-def translate_relation(rlt):
-    scs = open('{}.scs'.format(rlt['identifier']), 'wt', encoding='utf-8')
-    scs.write(rlt['identifier']+'\n')
-    scs.write('=> nrel_main_idtf:\n')
-    for lang, label in rlt['label'].items():
-        scs.write('\t[{}] (* <- lang_{};; *);\n'.format(label, lang))
-    scs.write(
-        '<- rrel_key_sc_element: ...\n(*\n\t<- sc_definition;;\n\t<= nrel_sc_text_translation:')
-    for lang, description in rlt['description'].items():
-        scs.write(
-            '\n\t\t... (* -> rrel_example: [{}] (* <-lang_{};; *);; *);'.format(description, lang))
-    scs.write(';\n*);\n')
-    scs.write('<-sc_node_norole_relation;;')
+def translate_relation(relation, template):
+    scs = open('{}.scs'.format(relation['identifier']), 'wt', encoding='utf-8')
+    scs.write(template.render(identifier=relation['identifier'], labels=relation['label'].items(
+    ), descriptions=relation['description'].items()))
     scs.close()

--- a/src/translators/JsonToScsTranslator.py
+++ b/src/translators/JsonToScsTranslator.py
@@ -11,28 +11,41 @@ def json_to_scs(raw_info, save_dir):
     except FileExistsError:
         pass
     os.chdir(save_dir)
-    try:
-        os.mkdir('images')
-    except FileExistsError:
-        pass
 
     info = json.loads(raw_info)
     jinja_env = Environment(loader=FileSystemLoader(os.path.realpath(
         '{}/../templates'.format(os.path.dirname(os.path.realpath(__file__))))))
 
+    try:
+        os.mkdir('entities')
+    except FileExistsError:
+        pass
+    os.chdir('entities')
+    try:
+        os.mkdir('images')
+    except FileExistsError:
+        pass
     template = jinja_env.get_template('entity.scs')
     for ent in info['entities'].values():
         translate_entity(ent, template)
+    os.chdir('..')
 
+    try:
+        os.mkdir('relations')
+    except FileExistsError:
+        pass
+    os.chdir('relations')
     template = jinja_env.get_template('relation.scs')
     for rlt in info['relations'].values():
         translate_relation(rlt, template)
+    os.chdir('..')
 
     template = jinja_env.get_template('triplets.scs')
     if len(info['triplets']) != 0:
         scs = open('triplets.scs', 'at', encoding='utf-8')
         scs.write(template.render(triplets=info['triplets']))
         scs.close()
+    os.chdir('..')
 
 
 def translate_entity(entity, template):


### PR DESCRIPTION
What was done:
* translator now use jinja2 templates for scs rendering
* arguments `--debug` and `--context` work like a flag now
* fixed definition of object type
* redesigned user input fix
* fixed identifier giving